### PR TITLE
Removes log for fileOpts

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,6 @@ module.exports = function (opts) {
 
 		var fileOpts = objectAssign(oDefaultOptions, opts);
 
-		console.log("fileOpts", fileOpts);
-
 		try {
 
 			aLogFileLines = [];


### PR DESCRIPTION
This Gulp plugin shouldn't log passed-in options (at least by default), since it's inconsistent with other plugins' console output.
